### PR TITLE
Moved away from defining URLs by hand

### DIFF
--- a/reflex
+++ b/reflex
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # reflex <surfraw-elvis> [i]    -> i == interactive
-# A tiny wrapper for surfraw that searches the highlighted text with chosen web service
+# A tiny wrapper for surfraw that searches the highlighted text with a chosen web service.
 
 set -euo pipefail
 
@@ -12,14 +12,14 @@ interactive=${2:-}
 if [[ $interactive ]]; then
     query=$(rofi -dmenu -p "$elvis")
 else
-    # Assumes Wayland. For X11, use `xclip -o`.
+    # I use wayland, replace this with your environment's equivalent.
     query=$(wl-paste --primary --no-newline)
 fi
 
 [[ -z "$query" ]] && exit 0
 
 # Get the URL from surfraw without opening it
-url=$(surfraw -print "$elvis" -- "$query")
+url=$(surfraw -print "$elvis" -- $query)
 
 # Open that URL with a specific browser (e.g., Vivaldi)
-vivaldi $url &>/dev/null &
+vivaldi $url

--- a/reflex
+++ b/reflex
@@ -10,7 +10,7 @@ elvis=${1:?Usage: $0 <surfraw_elvis> [i]}
 interactive=${2:-}
 
 if [[ $interactive ]]; then
-    query=$(rofi -dmenu -p "$elvis > ")
+    query=$(rofi -dmenu -p "$elvis >")
 else
     # I use wayland, replace this with your environment's equivalent.
     query=$(wl-paste --primary --no-newline)

--- a/reflex
+++ b/reflex
@@ -10,7 +10,7 @@ elvis_or_flag=${1:?Usage: $0 <surfraw_elvis>|-c|--choose [i]}
 interactive=${2:-}
 
 if [[ $elvis_or_flag == "-c" || $elvis_or_flag == "--choose" ]]; then
-    selection=$(surfraw -elvi | rofi -dmenu -p "elvis >")
+    selection=$(surfraw -elvi | grep -v 'ELVI:' | grep -v '^$' | rofi -dmenu -p "elvis >")
     [[ -z $selection ]] && exit 0
     elvis=${selection%%[[:space:]]*}
 else
@@ -22,9 +22,11 @@ fi
 if [[ $interactive ]]; then
     query=$(rofi -dmenu -p "$elvis >")
 else
+    # I use Wayland, replace this with your environment's equivalent.
     query=$(wl-paste --primary --no-newline)
 fi
 
 [[ -z "$query" ]] && exit 0
 
+# Let surfraw handle the browser invocation.
 surfraw "$elvis" -browser=vivaldi-stable "$query" &>/dev/null &

--- a/reflex
+++ b/reflex
@@ -10,7 +10,7 @@ elvis=${1:?Usage: $0 <surfraw_elvis> [i]}
 interactive=${2:-}
 
 if [[ $interactive ]]; then
-    query=$(rofi -dmenu -p "$elvis")
+    query=$(rofi -dmenu -p "$elvis > ")
 else
     # I use wayland, replace this with your environment's equivalent.
     query=$(wl-paste --primary --no-newline)

--- a/reflex
+++ b/reflex
@@ -18,8 +18,5 @@ fi
 
 [[ -z "$query" ]] && exit 0
 
-# Get the URL from surfraw without opening it
-url=$(surfraw -print "$elvis" -- $query)
-
-# Open that URL with a specific browser (e.g., Vivaldi)
-vivaldi $url
+# Let surfraw handle the browser invocation.
+surfraw "$elvis" -browser=vivaldi-stable $query &>/dev/null &

--- a/reflex
+++ b/reflex
@@ -1,13 +1,20 @@
 #!/usr/bin/env bash
-# reflex <surfraw-elvis> [i]    -> i == interactive
+# reflex <surfraw-elvis>|-c|--choose [i]  -> i == interactive
 # A tiny wrapper for surfraw that searches the highlighted text with a chosen web service.
 
 set -euo pipefail
 
 command -v surfraw >/dev/null || { echo "surfraw is not installed." >&2; exit 1; }
 
-elvis=${1:?Usage: $0 <surfraw_elvis> [i]}
+elvis=${1:?Usage: $0 <surfraw_elvis>|-c|--choose [i]}
 interactive=${2:-}
+
+# pick an elvis if requested
+if [[ $elvis == "-c" || $elvis == "--choose" ]]; then
+    elvis=$(surfraw -elvi | awk '{print $1}' | rofi -dmenu -p "elvis >")
+fi
+
+[[ -z "$elvis" ]] && exit 0
 
 if [[ $interactive ]]; then
     query=$(rofi -dmenu -p "$elvis >")
@@ -18,5 +25,4 @@ fi
 
 [[ -z "$query" ]] && exit 0
 
-# Let surfraw handle the browser invocation.
-surfraw "$elvis" -browser=vivaldi-stable $query &>/dev/null &
+surfraw "$elvis" -browser=vivaldi-stable "$query" &>/dev/null &

--- a/reflex
+++ b/reflex
@@ -1,42 +1,25 @@
 #!/usr/bin/env bash
-# reflex <service> [i]    -> i == interactive (uppercase binding)
-# author: Nivyan Lakhani
+# reflex <surfraw-elvis> [i]    -> i == interactive
+# A tiny wrapper for surfraw that searches the highlighted text with chosen web service
 
 set -euo pipefail
 
-service=$1                # w g c m …
-interactive=${2-""}       # "i" or ""
+command -v surfraw >/dev/null || { echo "surfraw is not installed." >&2; exit 1; }
 
-# -----------------------------------------------------------------------------
-# Build base-URL for every service
-# -----------------------------------------------------------------------------
+elvis=${1:?Usage: $0 <surfraw_elvis> [i]}
+interactive=${2:-}
 
-case "$service" in
-  w) base='https://en.wikipedia.org/w/index.php?search='             ;;
-  g) base='https://www.google.com/search?q='                         ;;
-  s) base='https://scholar.google.com/scholar?hl=en&as_sdt=0%2C5&q=' ;;
-  c) base='https://github.com/search?q='                             ;;
-  m) base='https://www.wolframalpha.com/input/?i='                   ;;
-  *) echo "unknown service"; exit 1                                  ;;
-esac
-
-urlencode() { jq -s -R -r @uri; }   # quick URL encoder via jq
-
-# -----------------------------------------------------------------------------
-# Get the query
-# -----------------------------------------------------------------------------
-#
 if [[ $interactive ]]; then
-    query=$(
-        rofi -show reflex \
-             -modi "reflex:~/.local/bin/reflex_complete ${service}"
-    )
+    query=$(rofi -dmenu -p "$elvis")
 else
-    # I use wayland, replace this with your environment's equivalent .
-    query=$(wl-paste --primary --no-newline | tr -d '\n')
+    # Assumes Wayland. For X11, use `xclip -o`.
+    query=$(wl-paste --primary --no-newline)
 fi
 
-[[ -z $query ]] && exit 0
+[[ -z "$query" ]] && exit 0
 
-# uses xdg-open. replace it to specify a browser
-xdg-open "${base}$(printf '%s' "$query" | urlencode)" >/dev/null 2>&1 &
+# Get the URL from surfraw without opening it
+url=$(surfraw -print "$elvis" -- "$query")
+
+# Open that URL with a specific browser (e.g., Vivaldi)
+vivaldi $url &>/dev/null &

--- a/reflex
+++ b/reflex
@@ -1,17 +1,20 @@
 #!/usr/bin/env bash
-# reflex <surfraw-elvis>|-c|--choose [i]  -> i == interactive
+# reflex <surfraw-elvis>|-c|--choose [i]    -> i == interactive
 # A tiny wrapper for surfraw that searches the highlighted text with a chosen web service.
 
 set -euo pipefail
 
 command -v surfraw >/dev/null || { echo "surfraw is not installed." >&2; exit 1; }
 
-elvis=${1:?Usage: $0 <surfraw_elvis>|-c|--choose [i]}
+elvis_or_flag=${1:?Usage: $0 <surfraw_elvis>|-c|--choose [i]}
 interactive=${2:-}
 
-# pick an elvis if requested
-if [[ $elvis == "-c" || $elvis == "--choose" ]]; then
-    elvis=$(surfraw -elvi | awk '{print $1}' | rofi -dmenu -p "elvis >")
+if [[ $elvis_or_flag == "-c" || $elvis_or_flag == "--choose" ]]; then
+    selection=$(surfraw -elvi | rofi -dmenu -p "elvis >")
+    [[ -z $selection ]] && exit 0
+    elvis=${selection%%[[:space:]]*}
+else
+    elvis=$elvis_or_flag
 fi
 
 [[ -z "$elvis" ]] && exit 0
@@ -19,7 +22,6 @@ fi
 if [[ $interactive ]]; then
     query=$(rofi -dmenu -p "$elvis >")
 else
-    # I use wayland, replace this with your environment's equivalent.
     query=$(wl-paste --primary --no-newline)
 fi
 


### PR DESCRIPTION
Now we rely on the `surfraw` library to provide URL params instead of
self-defining them. This PR closes #2 and is incompatible with previous versions
of the script.